### PR TITLE
Allow both createNetwork and createEnvironment to save.

### DIFF
--- a/createEnvironment.m
+++ b/createEnvironment.m
@@ -1,0 +1,71 @@
+function environment = createEnvironment(numRewards, maxReward, rewardDistFunc, nodeDropout, randomness, saveEnvironmentFlag)
+  % Given the reward and randomness parameters, createEnvironment generates a struct 
+  % representing the initial conditions for an environment.
+  %
+  % numRewards: must be greater than 0
+  % maxReward: reward values will be distributed in the range (0, maxReward]
+  % rewardDistFunc: uniformInteger, uniformCont, gaussianInteger, gaussianCont
+  % nodeDropout: the probability that a node will dropout of the network for any given time
+  %              step. Must be in the range [0,1)
+  % randomness: none 0, low (0,0.15], medium (0.15-0.3], high (0.3-1]
+  % saveEnvironmentFlag: set to 1 if you want to save the environment struct as a MATLAB object
+   
+  %% Populate the rewards vector according to numRewards, maxReward and the rewardDistFunc 
+  switch rewardDistFunc
+    case 'uniformInteger'
+      rewards = randi([1 maxReward],numRewards,1);
+    case 'uniformCont'
+      rewards = (maxReward - 1) * rand([numRewards 1]) + 1;
+    case 'gaussianInteger'
+      disp('gaussianInteger is not implemented. You can help by coding this yourself.');
+      keyboard
+    case 'gaussianContinuous'
+      disp('gaussianContinuous is not implemented. You can help by coding this yourself.');
+      keyboard
+    otherwise
+      disp(['ERROR: Unrecognized rewardDistFunc term ' rewardDistFunc '. Should be uniformInteger, uniformCont, gaussianInteger, gaussianCont.'])
+      keyboard
+  end
+  
+  %% Pick an appropriate value for the environment's stochasticity. This will be 
+  % used as noise during value perception.
+  switch randomness
+    case 'none'
+      environmentStochasticity = 0;
+    case 'low'
+      environmentStochasticity = rand() * 0.15;
+    case 'medium'
+      environmentStochasticity = 0.15 + (rand() * 0.15);
+    case 'high'
+      environmentStochasticity = 0.3 + (rand() * 0.7);
+    otherwise
+      disp(['ERROR: Unrecognized randomness term ' randomness '. Should be none, low, medium or high.'])
+      keyboard
+  end
+  
+  %% Ensure that the node dropout rate is in the interval [0,1).
+  if nodeDropout >= 1 || nodeDropout < 0
+    disp('nodeDropout must be in the interval [0,1).');
+    keyboard
+  end
+  
+  %% global urgency starts at 0.
+  globalUrgency = 0;
+  
+  %% At some point, initialize the global urgency update equation.
+  %% Or initialize the global urgency equation's coefficients.
+  
+  %% Create the struct to be returned.
+  environment = struct('rewards', rewards, 'stochasticity', environmentStochasticity, ...
+  'nodeDropRate', nodeDropout, 'urgency', globalUrgency);
+  
+  if saveEnvironmentFlag
+    c = clock;
+  
+    filename = strcat('environment_',num2str(c(3)), num2str(c(2)), num2str(c(1)), num2str(c(4)), ...
+    num2str(c(5)), c(6),'.mat');
+  
+    save(filename, 'environment'); 
+   end
+  
+end

--- a/createNetwork.m
+++ b/createNetwork.m
@@ -1,4 +1,4 @@
-function [newNetwork, T, smallWorldMeasure, lambda, gamma] = createNetwork (N, K, q, displayFlag)
+function [newNetwork, T, smallWorldMeasure, lambda, gamma] = createNetwork (N, K, q, displayFlag, saveNetworkFlag)
     % Given a number of nodes, N, a degree of connectedness,
     % K, and a rewiring proportion, q, generates and returns
     % a graph object.
@@ -154,12 +154,14 @@ function [newNetwork, T, smallWorldMeasure, lambda, gamma] = createNetwork (N, K
         disp('Weights for network: ');
         disp(W.*A);
     end
+    
     %% measuring small-world-ness
     % small-world-ness S = 
     % to measure small-world-ness, we will use measures detailed in Xu 2010
     % these require that we calculate the shortest path length between each
     % two nodes, and the clustering coefficient for our network, and a
     % random network
+    
     [charPathLength, clusterCoeff] = networkStats(newNetwork);
     % do the same for a randomly generated network
     randomNetwork = generateRandomNetwork(N,numedges(newNetwork),'uniform');
@@ -181,5 +183,16 @@ function [newNetwork, T, smallWorldMeasure, lambda, gamma] = createNetwork (N, K
     if displayFlag
         disp(['Small-world measure: ' num2str(smallWorldMeasure)]);
         disp(['Clustering coefficient ratio (gamma): ' num2str(gamma) ', characteristic path length ratio: ' num2str(lambda)]);  
+    end
+    
+    %% save network object (maybe)
+    if saveNetworkFlag
+        networkObject = struct('networkObject', newNetwork, 'timeDelayMatrix', T, ...
+            'smallWorldMeasure', smallWorldMeasure, 'clusteringCoefficientRatio', gamma, ...
+            'characteristicPathLengthRatio', lambda, 'weightRange', weightRange, ...
+            'timeDelayRange', timeDelayRange);
+        runID = datetime;
+        runID = datestr(runID,'ddmmyy_HHMMSS');
+        save(['networkObj_' runID], 'networkObject');
     end
 end

--- a/smallWorldTrials.m
+++ b/smallWorldTrials.m
@@ -6,9 +6,9 @@ randomseed = randi(100);
 rng(randomseed);
 
 % number of nodes in networks
-N = 1000;
+N = 250;
 % 2 * number of connected neighbors (K on either side)
-K = 10;
+K = 25;
 % rewiring probabilities
 q = 0:0.02:0.5;
 % number of networks to simulate in each condition ("samples")
@@ -19,11 +19,16 @@ clusterCoeffRatio = NaN(length(q), numTrialNetworks);   % gamma
 charPathLengthRatio = NaN(length(q), numTrialNetworks); % lambda
 
 for qix = 1:length(q)
-    disp(['q = ' num2str(q(qix))]);
+    tic
+    disp(['*** q = ' num2str(q(qix))]);
     for t = 1:numTrialNetworks
+        if mod(t,10)==0
+            disp(t);
+        end
         [~, T, smallWorldMeasure(qix,t), clusterCoeffRatio(qix,t), charPathLengthRatio(qix,t)] = ...
-            createNetwork(N, K, q(qix), 0);
+            createNetwork(N, K, q(qix), 0, 0);
     end
+    toc
 end
 
 % compute mean of all measures as a function of q
@@ -47,6 +52,7 @@ xlabel('Rewiring probability');
 ylabel('Small-world measure');
 title(['N = ' num2str(N) ', K = ' num2str(K) ', nsamples = ' num2str(numTrialNetworks)]);
 hold off;
+saveas(gca, ['smallWorldMeasure_N' num2str(N) '_K' num2str(K) '_' num2str(numTrialNetworks)]);
 
 % cluster coefficient ratio (gamma) and characteristic path length ratio
 % (lambda)
@@ -61,5 +67,6 @@ errorbar(q, meanPL, semPL, 'xr');
 xlabel('Rewiring probability');
 title(['N = ' num2str(N) ', K = ' num2str(K) ', nsamples = ' num2str(numTrialNetworks)]);
 hold off;
+saveas(gca, ['gamma&lambda_N' num2str(N) '_K' num2str(K) '_' num2str(numTrialNetworks)]);
 
 


### PR DESCRIPTION
Both createNetwork and createEnvironment now have "save flag" as a parameter. If it is set, then the relevant variables are saved into the current directory as a MATLAB .mat file.